### PR TITLE
Add isolated RGB stock snapshots

### DIFF
--- a/src/persistence/stock.rs
+++ b/src/persistence/stock.rs
@@ -401,6 +401,13 @@ impl Stock {
     pub fn in_memory() -> Self {
         Self::with(MemStash::in_memory(), MemState::in_memory(), MemIndex::in_memory())
     }
+
+    /// Creates an independent in-memory snapshot without carrying over persistence providers.
+    ///
+    /// Mutating or storing the returned stock cannot modify the source stock. This is useful for
+    /// preparing multi-step operations before atomically promoting their resulting state.
+    #[inline]
+    pub fn snapshot(&self) -> Self { self.clone_no_persistence() }
 }
 
 impl<S: StashProvider, H: StateProvider, I: IndexProvider> Stock<S, H, I> {
@@ -1774,6 +1781,27 @@ mod test {
         if let Ok(schema) = stock.export_schema(schema_id) {
             println!("{:?}", schema.kit_id())
         }
+    }
+
+    #[test]
+    fn stock_snapshot_isolated_from_source() {
+        let source = Stock::in_memory();
+        let seal = GraphSeal::new_random_vout(Vout::from_u32(1));
+        let secret = seal.conceal();
+        let mut snapshot = source.snapshot();
+
+        snapshot.store_secret_seal(seal).unwrap();
+
+        assert!(source
+            .as_stash_provider()
+            .seal_secret(secret)
+            .unwrap()
+            .is_none());
+        assert!(snapshot
+            .as_stash_provider()
+            .seal_secret(secret)
+            .unwrap()
+            .is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an explicit `Stock::snapshot()` API backed by `clone_no_persistence()`
- guarantee that staged stock mutations cannot modify the source persistence providers
- cover source/snapshot isolation with a focused unit test

## Motivation

Transactional RGB acceptance needs to validate and stage state changes without publishing partial stock state. This small primitive makes that ownership boundary explicit and testable.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test --workspace --all-features`
- Result: 39 passed, 0 failed

## Dependency

This PR is independent at the source level. It is consumed by the transactional acceptance work in rgb-lib.